### PR TITLE
FIX: MySQL Storage adapter passing malformed arguments to mysql binary.

### DIFF
--- a/lib/sequel-rails/storage.rb
+++ b/lib/sequel-rails/storage.rb
@@ -1,3 +1,4 @@
+require 'shellwords'
 module Rails
   module Sequel
 
@@ -140,9 +141,9 @@ module Rails
 
         def execute(statement)
           commands = ["mysql"]
-          commands << "--user" << username unless username.blank?
-          commands << "--password" << password unless password.blank?
-          commands << "--host" << host unless host.blank?
+          commands << "--user=#{Shellwords.escape(username)}" unless username.blank?
+          commands << "--password=#{Shellwords.escape(password)}" unless password.blank?
+          commands << "--host=#{host}" unless host.blank?
           commands << "-e" << statement
           system(*commands)
         end


### PR DESCRIPTION
`mysql` command line parameters are in the format of:

"--foo=bar" not "--foo bar"
