### PR TITLE
Postgres: Handle configuration parameters for db:drop and db:create

### DIFF
--- a/lib/sequel_rails/storage/postgres.rb
+++ b/lib/sequel_rails/storage/postgres.rb
@@ -10,7 +10,7 @@ module SequelRails
         commands << "--host" << host unless host.blank?
         commands << database
         res = system(*commands)
-        ENV["PGPASSWORD"] = nil
+        ENV["PGPASSWORD"] = nil unless password.blank?
         res
       end
 
@@ -22,7 +22,7 @@ module SequelRails
         commands << "--host" << host unless host.blank?
         commands << database
         res = system(*commands)
-        ENV["PGPASSWORD"] = nil
+        ENV["PGPASSWORD"] = nil unless password.blank?
         res
       end
     end


### PR DESCRIPTION
Fixes 3 minor issues:
- `rake db:drop` => give port number, host name and password to postgresql
- `rake db:create` & `db:drop` => turn port number into a string before adding it
- `rake db:create` & `db:drop` => unset password only if it was set here (It might come from the system environment rather than from config file)
