### PR TITLE
Don't change default value for Sequel::Model.raise_on_save_failure

### DIFF
--- a/lib/sequel_rails/railtie.rb
+++ b/lib/sequel_rails/railtie.rb
@@ -66,7 +66,6 @@ module SequelRails
       ::Sequel::Model.plugin :active_model
       ::Sequel::Model.plugin :validation_helpers
       ::Sequel::Model.plugin :rails_extensions
-      ::Sequel::Model.raise_on_save_failure = false
     end
 
     # Support overwriting crucial steps in subclasses

--- a/spec/lib/sequel_rails/railtie_spec.rb
+++ b/spec/lib/sequel_rails/railtie_spec.rb
@@ -72,9 +72,6 @@ describe SequelRails::Railtie do
     it "to use :rails_extensions plugin" do
       plugins.should include Sequel::Plugins::RailsExtensions
     end
-    it "to not raise on save failure" do
-      Sequel::Model.raise_on_save_failure.should be false
-    end
   end
 
   it "configures database in Sequel" do


### PR DESCRIPTION
Sequel documentation explicitly states that the default for `Sequel::Model.raise_on_save_failure` is `true`. We should respect that, unless there's a very compelling reason to override the default at the cost of confusing users.
