### PR TITLE
Improved the JRuby check

### DIFF
--- a/lib/sequel_rails.rb
+++ b/lib/sequel_rails.rb
@@ -6,7 +6,7 @@ module SequelRails
     @using_jruby ||= if defined?(RUBY_ENGINE)
       RUBY_ENGINE == "jruby"
     else
-      ENV['RUBY_VERSION'].to_s =~ /jruby/
+      defined?(JRUBY_VERSION)
     end
   end
 end


### PR DESCRIPTION
- We discovered the bug that you already mostly-fixed in one of @JackDanger's recent pull requests. Since the bug still exists, this fixes it.
- `ENV['RUBY_VERSION']` under JRuby will be something like `"ruby-1.9.3-p327"`.
- `JRUBY_VERSION` will be defined and something like `"1.7.2"` under JRuby and undefined other rubies.
- I would write the `SequelRails.jruby?` method without memoization (because there
  are no performance ramifications) as a one-liner, but it's a style preference:

``` ruby
def self.jruby?
  (defined?(RUBY_ENGINE) && RUBY_ENGINE == "jruby") || defined?(JRUBY_VERSION)``
end
```
