### PR TITLE
Allow configuring max connections in the app config.

### DIFF
--- a/lib/sequel_rails/configuration.rb
+++ b/lib/sequel_rails/configuration.rb
@@ -72,6 +72,9 @@ module SequelRails
         end
       end
 
+      # override max connections if requested in app configuration
+      config['max_connections'] = max_connections if max_connections
+      
       # some adapters only support an url
       if config['adapter'] && config['adapter'] =~ /^(jdbc|do):/
         params = {}


### PR DESCRIPTION
Hi, I found it useful to have a method to override max_connections from the app config. On heroku the database config file is autogenerated; in principle it's possible to configure max_connections in a query option on database url, but this is something which is easy to forget and the connection pool size is something rather app-specific anyway.

The patch makes it possible to override max connections in the application configuration, so eg. if you put 

``` ruby
  config.sequel.max_connections = 16
```

in config/environments/production.rb you get connection pool size 16 in production environment.

See also the discussion at https://github.com/jeremyevans/sequel/issues/638
