### PR TITLE
Use Postgres adapter method for dropdb and createdb in the jdbc adapter so we get username,password,host and port settings

### DIFF
--- a/lib/sequel_rails/storage/jdbc.rb
+++ b/lib/sequel_rails/storage/jdbc.rb
@@ -35,7 +35,7 @@ module SequelRails
             db.execute("CREATE DATABASE IF NOT EXISTS `#{db_name}` DEFAULT CHARACTER SET #{charset} DEFAULT COLLATE #{collation}")
           end
         elsif _is_postgres?
-          system("createdb #{db_name}")
+          Postgres.new(config)._create
         end
       end
 
@@ -48,7 +48,7 @@ module SequelRails
             db.execute("DROP DATABASE IF EXISTS `#{db_name}`")
           end
         elsif _is_postgres?
-          system("dropdb #{db_name}")
+          Postgres.new(config)._drop
         end
       end
 


### PR DESCRIPTION
Currently if you use JRuby and connect to a postgres database it will not use the database host,port,username or password settings in database.yml when it drops or creates a database.  The postrges adapter does use all of these settings.  This change changes the jdbc adapter to use the postgres adabter's implementation to drop and create a database.
