### PR TITLE
Changed gem dependencies to work with all future versions of Sequel 4.

### DIFF
--- a/sequel-rails.gemspec
+++ b/sequel-rails.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.extra_rdoc_files = ["LICENSE", "README.md"]
   s.rdoc_options = ["--charset=UTF-8"]
 
-  s.add_runtime_dependency "sequel", [">= 3.28", "< 4.1.0"]
+  s.add_runtime_dependency "sequel", [">= 3.28", "< 5.0"]
   s.add_runtime_dependency "railties", ">= 3.2.0"
 
   s.add_development_dependency "rake", ">= 0.8.7"


### PR DESCRIPTION
Sequel generally has a new minor point release every month. There shouldn't be any major API changes until 5.0 is released. As such, there is no reason to expect that this gem won't work with any release of 4 and shouldn't be restricted not to.
