### PR TITLE
Apply all migrations in the schema.rb file when loading the schema

### DIFF
--- a/lib/sequel_rails/railties/database.rake
+++ b/lib/sequel_rails/railties/database.rake
@@ -33,7 +33,7 @@ namespace :db do
       if File.exists?(file)
         require 'sequel/extensions/migration'
         load(file)
-        ::Sequel::Migration.descendants.first.apply(db_for_current_env, :up)
+        ::Sequel::Migration.descendants.each{|m| m.apply(db_for_current_env, :up)}
       else
         abort %{#{file} doesn't exist yet. Run "rake db:migrate" to create it then try again. If you do not intend to use a database, you should instead alter #{Rails.root}/config/boot.rb to limit the frameworks that will be loaded}
       end


### PR DESCRIPTION
The schema dump command will always have more than a single migration due to migration version information being separate.

This makes the load command apply to all migrations in the schema.rb file whether it be one or a thousand.
