### PR TITLE
Fixed bug where SQL schema dumps using timestamp migration had broken sy...

### DIFF
--- a/lib/sequel_rails/migrations.rb
+++ b/lib/sequel_rails/migrations.rb
@@ -25,7 +25,7 @@ module SequelRails
 
         inserts = migrator.ds.map do |hash|
           insert = migrator.ds.insert_sql(hash)
-          sql ? insert : "    self << #{insert.inspect}"
+          sql ? "#{insert};" : "    self << #{insert.inspect}"
         end
         res = ""
         if inserts.any?


### PR DESCRIPTION
...ntax due to missing semicolons.

If you have to make multiple inserts into schema_migrations, they aren't separated by semicolons which causes loading the structure not to work. (At least, that's the case in PostgreSQL.)
