### PR TITLE
attribute accessor was moved to module directory in 4.1

### DIFF
--- a/lib/sequel_rails/configuration.rb
+++ b/lib/sequel_rails/configuration.rb
@@ -1,4 +1,4 @@
-if Gem.loaded_specs['rails'].version.to_s =~ /^4\.1.+/
+if Gem.loaded_specs['rails'] && Gem.loaded_specs['rails'].version.to_s =~ /^4\.1.+/
   require 'active_support/core_ext/module/attribute_accessors'
 else
   require 'active_support/core_ext/class/attribute_accessors'


### PR DESCRIPTION
Hi,
  I've made a backwards compatible modification  in the configuration.rb file that removes a deprecation
  warning in Rails 4.1

Regards,
Sebastian.
