### PR TITLE
Use DATABASE_URL envar even if there's no config

### DIFF
--- a/lib/sequel_rails/configuration.rb
+++ b/lib/sequel_rails/configuration.rb
@@ -33,7 +33,10 @@ module SequelRails
     end
 
     def environments
-      @environments ||= raw.reduce({}) do |normalized, environment|
+      @environments ||= raw.reduce(
+        # default config - use just the environment variable
+        Hash.new normalize_repository_config({})
+      ) do |normalized, environment|
         name, config = environment.first, environment.last
         normalized[name] = normalize_repository_config(config)
         normalized


### PR DESCRIPTION
Without this change support of Rails 4.1 with sequel on Heroku is broken.
cf. https://discussion.heroku.com/t/rails-4-1-database-yml-no-longer-overwritten-on-heroku/550
