### PR TITLE
Do not attempt to destroy not persisted session

### DIFF
--- a/lib/action_dispatch/middleware/session/sequel_store.rb
+++ b/lib/action_dispatch/middleware/session/sequel_store.rb
@@ -37,7 +37,8 @@ module ActionDispatch
       def destroy_session(env, sid, options)
         sid = current_session_id(env)
         if sid
-          get_session_model(env, sid).destroy
+          session = get_session_model(env, sid)
+          session.destroy unless session.new?
           env[SESSION_RECORD_KEY] = nil
         end
 


### PR DESCRIPTION
Otherwise Sequel is raising error like this:

(Sequel::NoExistingObject) "Attempt to delete object did not result in a single row modification (Rows Deleted: 0, SQL: DELETE FROM \"sessions\" WHERE (\"id\" IS NULL))"
