### PR TITLE
Fix ActiveModel I18n integration

### DIFF
--- a/lib/sequel_rails/railtie.rb
+++ b/lib/sequel_rails/railtie.rb
@@ -70,7 +70,8 @@ module SequelRails
     end
 
     def setup_i18n_support
-      ::Sequel::Model.send :include, ::SequelRails::I18nSupport
+      ::Sequel::Model.send :extend, ::ActiveModel::Translation
+      ::Sequel::Model.send :extend, ::SequelRails::I18nSupport
     end
 
     def setup_controller_runtime

--- a/lib/sequel_rails/railties/i18n_support.rb
+++ b/lib/sequel_rails/railties/i18n_support.rb
@@ -4,5 +4,11 @@ module SequelRails
     def i18n_scope #:nodoc:
       :sequel
     end
+
+    def lookup_ancestors
+      # ActiveModel uses the name of ancestors. Exclude unnamed classes, like
+      # those returned by Sequel::Model(...).
+      super.reject { |x| x.name.nil? }
+    end
   end
 end

--- a/spec/lib/sequel_rails/railtie_spec.rb
+++ b/spec/lib/sequel_rails/railtie_spec.rb
@@ -56,7 +56,9 @@ describe SequelRails::Railtie do
   end
 
   it 'configures Sequel::Model instances for i18n' do
-    expect(User.new.i18n_scope).to be(:sequel)
+    expect(User.i18n_scope).to be(:sequel)
+    expect(User).to respond_to(:lookup_ancestors)
+    expect(User.model_name.human).to eq('translated user')
   end
 
   it 'adds Sequel runtime to controller for logging' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,6 +20,16 @@ rspec_exclusions[:sqlite] = ENV['TEST_ADAPTER'] != 'sqlite3'
 
 RSpec.configure do |config|
   config.filter_run_excluding rspec_exclusions
+
+  config.before(:all) do
+    I18n.backend.store_translations(
+      :en,
+      'sequel' => {
+        'models' => {
+          'user' => 'translated user' }
+      })
+  end
+
   config.around :each do |example|
     if example.metadata[:no_transaction]
       example.run


### PR DESCRIPTION
:i18n_scope is supposed to be a class method. Also, to humanize model names
:lookup_ancestors is required (provided by ActiveModel::Translation).
