### PR TITLE
allow db: namespace to be reconfigured to something else, eg sequel:

### DIFF
--- a/lib/sequel_rails/railtie.rb
+++ b/lib/sequel_rails/railtie.rb
@@ -36,7 +36,13 @@ module SequelRails
     config.sequel = ::SequelRails::Configuration.new
 
     rake_tasks do |app|
-      load 'sequel_rails/railties/database.rake' if app.config.sequel.load_database_tasks
+      load_tasks_config = app.config.sequel.load_database_tasks
+      SequelRails::TASK_NAMESPACE =
+      case load_tasks_config
+      when Symbol, String; load_tasks_config.to_sym
+      else :db
+      end
+      load 'sequel_rails/railties/database.rake' if load_tasks_config
     end
 
     initializer 'sequel.load_hooks' do |app|


### PR DESCRIPTION
Because of rails_admin, I had to pull ActiveRecord into a project that I'd already configured for Sequel with sequel-rails. ```rake db:migrate``` would fail.
This pull request allows the ```db:``` rake namespace to be configured using something like ```config.sequel.load_database_tasks = :sequel```, but preserves existing behaviour.
Now I (and capistrano, with some work) can say ```rake sequel:migrate``` and things work as expected.
