### PR TITLE
Make sure the Sequel.connect hash has symbols as keys.

### DIFF
--- a/lib/sequel_rails/configuration.rb
+++ b/lib/sequel_rails/configuration.rb
@@ -54,9 +54,9 @@ module SequelRails
       end
 
       if normalized_config['url']
-        ::Sequel.connect normalized_config['url'], normalized_config
+        ::Sequel.connect normalized_config['url'], normalized_config.deep_symbolize_keys
       else
-        ::Sequel.connect normalized_config
+        ::Sequel.connect normalized_config.deep_symbolize_keys
       end.tap { after_connect.call if after_connect.respond_to?(:call) }
     end
 


### PR DESCRIPTION
Sequel expects the config hash to have symbolized keys, but sequel-rails is passing it a HashWithIndifferentAccess which returns strings if you inspect it (e.g. config.keys will give you an array of strings instead of symbols).

Sequel.connect() internally attempts to fix this but it only works on the outer hash, it doesn't fix any nested hashes.

This prevents the sharding :servers option from working.
Example: http://sequel.jeremyevans.net/rdoc/files/doc/sharding_rdoc.html#label-Single+Read-Only+Slave-2C+Single+Master

It should be as simple as adding:
```
  servers:
    read_only:
      host: other_server
```
to your database.yml but this won't work unless the keys are symbols when passed to Sequel.connect