### PR TITLE
Fix bug if Spring is defined but Spring::Application is not

### DIFF
--- a/lib/sequel_rails/railtie.rb
+++ b/lib/sequel_rails/railtie.rb
@@ -72,7 +72,7 @@ module SequelRails
     end
 
     initializer 'sequel.spring' do |app|
-      if defined?(::Spring)
+      if defined?(::Spring::Application)
         class ::Spring::Application
           include ::SequelRails::SpringSupport
           alias_method_chain :disconnect_database, :sequel


### PR DESCRIPTION
Hey,

I went a little too trigger happy on the last PR, when doing `rake db:migrate` for example, it seems Spring is defined but Spring::Application is not, and it makes the thing crash. Fixed with this.