### PR TITLE
preliminary rails 5 and rack 2 support

### DIFF
--- a/lib/action_dispatch/middleware/session/sequel_store.rb
+++ b/lib/action_dispatch/middleware/session/sequel_store.rb
@@ -7,7 +7,7 @@ module ActionDispatch
   module Session
     class SequelStore < AbstractStore
       SESSION_RECORD_KEY = 'rack.session.record'.freeze
-      ENV_SESSION_OPTIONS_KEY = Rack::Session::Abstract::ENV_SESSION_OPTIONS_KEY
+      ENV_SESSION_OPTIONS_KEY = 'rack.session.options'.freeze
 
       cattr_accessor :session_class
       def self.session_class


### PR DESCRIPTION
ENV_SESSION_OPTIONS_KEY is no longed defined in the Rack:Session::Abstract module of Rack 2.0, so I replaced it with it's original value.