### PR TITLE
Support specifying 'url' in configuration files

### DIFF
--- a/lib/sequel_rails/storage.rb
+++ b/lib/sequel_rails/storage.rb
@@ -55,18 +55,27 @@ module SequelRails
 
     def self.with_local_repositories
       ::SequelRails.configuration.environments.each_value do |config|
-        next if config['database'].blank? || config['adapter'].blank?
-        if config['host'].blank? || %w( 127.0.0.1 localhost ).include?(config['host'])
+        url = URI(config['url']) if config['url'].present?
+        database = config['database'] || url.try(:path).try(:[], 1..-1)
+        adapter  = config['adapter'] || url.try(:scheme)
+        host     = config['host'] || url.try(:host)
+
+        next if database.blank? || adapter.blank?
+        if host.blank? || %w( 127.0.0.1 localhost ).include?(host)
           yield config
         else
-          warn "This task only modifies local databases. #{config['database']} is on a remote host."
+          warn "This task only modifies local databases. #{database} is on a remote host."
         end
       end
     end
 
     def self.with_all_repositories
       ::SequelRails.configuration.environments.each_value do |config|
-        next if config['database'].blank? || config['adapter'].blank?
+        url = URI(config['url']) if config['url'].present?
+        database = config['database'] || url.try(:path).try(:[], 1..-1)
+        adapter  = config['adapter'] || url.try(:scheme)
+
+        next if database.blank? || adapter.blank?
         yield config
       end
     end

--- a/lib/sequel_rails/storage/abstract.rb
+++ b/lib/sequel_rails/storage/abstract.rb
@@ -5,6 +5,7 @@ module SequelRails
 
       def initialize(config)
         @config = config
+        parse_url
       end
 
       def create
@@ -92,6 +93,20 @@ module SequelRails
       end
 
       private
+
+      def parse_url
+        return unless @config['url'].present?
+
+        url = URI(@config['url'])
+
+        @config.reverse_merge!(
+          'database' => url.path.try(:[], 1..-1),
+          'username' => url.userinfo.try(:split, ':').try(:first),
+          'password' => url.userinfo.try(:split, ':').try(:last),
+          'host' => url.host,
+          'port' => url.port,
+        )
+      end
 
       def add_option(commands, name, value)
         return unless value.present?

--- a/spec/lib/sequel_rails/storage_spec.rb
+++ b/spec/lib/sequel_rails/storage_spec.rb
@@ -12,10 +12,9 @@ describe SequelRails::Storage do
       },
       'test' => {
         'adapter' => 'postgres',
+        'url' => 'postgres://127.0.0.1/sequel_rails_test_storage_test',
         'owner' => (ENV['TEST_OWNER'] || ENV['USER']),
         'username' => (ENV['TEST_OWNER'] || ENV['USER']),
-        'database' => 'sequel_rails_test_storage_test',
-        'host' => '127.0.0.1',
       },
       'remote' => {
         'adapter' => 'postgres',


### PR DESCRIPTION
Right now this works fine for all Sequel connections, but breaks for all rake tasks since the URL isn't parsed. This ends up being a deal breaker when using `sequel-rails` with a `config/database.yml` that looks like this:

```
...
development:
  url:  <%= ENV['DATABASE_URL'] %>
...
```

This adds support to the Storage helpers, which fixes the rake tasks.