### PR TITLE
Trim trailing spaces at templates

### DIFF
--- a/lib/generators/sequel/model/templates/migration.rb.erb
+++ b/lib/generators/sequel/model/templates/migration.rb.erb
@@ -1,4 +1,4 @@
-Sequel.migration do 
+Sequel.migration do
   change do
 
     create_table :<%= table_name %> do

--- a/lib/generators/sequel/model/templates/model.rb.erb
+++ b/lib/generators/sequel/model/templates/model.rb.erb
@@ -2,5 +2,5 @@ class <%= class_name %><%= options[:parent] ? " < #{options[:parent].classify}" 
   <%- if options[:timestamps] -%>
   plugin :timestamps
   <%- end -%>
-  
+
 end


### PR DESCRIPTION
Generated files have trailing spaces that some linters like rubocop complain about.