### PR TITLE
Allow multiple db/migrate directories to work in your application.

### DIFF
--- a/lib/sequel_rails/migrations.rb
+++ b/lib/sequel_rails/migrations.rb
@@ -86,7 +86,7 @@ module SequelRails
           end
         end
         if explanation && copy_files.any?
-          puts "Detected migration files outside of the main db/migrate directory. Copying them to db/migrate temporarily to #{explanation}:"
+          puts "SequelRails: Detected migration files outside of the main db/migrate directory. Copying them to db/migrate temporarily to #{explanation}:"
           copy_files.each { |o, _| puts " - #{o}"}
         end
         copy_files.each { |original, destination| FileUtils.cp(original, destination) }

--- a/lib/sequel_rails/migrations.rb
+++ b/lib/sequel_rails/migrations.rb
@@ -72,9 +72,10 @@ module SequelRails
         end
       end
 
-      # Temporarily merges the migration files and then moves them back. Sequel's migration class cannot work
-      # with migrations in different directories even if sequel-rails can. This is the simplest solution that works
-      # until ::Sequel::Migrator supports merging of multiple migration directories.
+      # Temporarily merges the migration files by copying them over and then deletes them.
+      # Sequel's migration class cannot work with migrations in different directories even if sequel-rails can.
+      # This is the simplest solution that works until ::Sequel::Migrator supports merging of multiple migration
+      # directories.
       def temporarily_merge_migration_files(explanation=nil)
         copy_files = []
         Rails.application.config.paths["db/migrate"].expanded.each do |specified_migration_dir|

--- a/lib/sequel_rails/migrations.rb
+++ b/lib/sequel_rails/migrations.rb
@@ -6,14 +6,18 @@ module SequelRails
       def migrate(version = nil)
         opts = {}
         opts[:target] = version.to_i if version
-        ::Sequel::Migrator.run(::Sequel::Model.db, migrations_dir, opts)
+        temporarily_merge_migration_files("run the migration") do
+          ::Sequel::Migrator.run(::Sequel::Model.db, migrations_dir, opts)
+        end
       end
       alias_method :migrate_up!, :migrate
       alias_method :migrate_down!, :migrate
 
       def pending_migrations?
         return false unless available_migrations?
-        !::Sequel::Migrator.is_current?(::Sequel::Model.db, migrations_dir)
+        temporarily_merge_migration_files do
+          !::Sequel::Migrator.is_current?(::Sequel::Model.db, migrations_dir)
+        end
       end
 
       def dump_schema_information(opts = {})
@@ -23,9 +27,11 @@ module SequelRails
         res = ''
 
         if available_migrations?
-          migrator_class = ::Sequel::Migrator.send(:migrator_class, migrations_dir)
-          migrator = migrator_class.new db, migrations_dir
-          res << adapter.schema_information_dump(migrator, sql)
+          temporarily_merge_migration_files do
+            migrator_class = ::Sequel::Migrator.send(:migrator_class, migrations_dir)
+            migrator = migrator_class.new db, migrations_dir
+            res << adapter.schema_information_dump(migrator, sql)
+          end
         end
         res
       end
@@ -36,31 +42,58 @@ module SequelRails
 
       def current_migration
         return unless available_migrations?
-
-        migrator_class = ::Sequel::Migrator.send(:migrator_class, migrations_dir)
-        migrator = migrator_class.new ::Sequel::Model.db, migrations_dir
-        if migrator.respond_to?(:applied_migrations)
-          migrator.applied_migrations.last
-        elsif migrator.respond_to?(:current_version)
-          migrator.current_version
+        temporarily_merge_migration_files("determine the current_migration") do
+          migrator_class = ::Sequel::Migrator.send(:migrator_class, migrations_dir)
+          migrator = migrator_class.new ::Sequel::Model.db, migrations_dir
+          if migrator.respond_to?(:applied_migrations)
+            migrator.applied_migrations.last
+          elsif migrator.respond_to?(:current_version)
+            migrator.current_version
+          end
         end
       end
 
       def previous_migration
         return unless available_migrations?
-
-        migrator_class = ::Sequel::Migrator.send(:migrator_class, migrations_dir)
-        migrator = migrator_class.new ::Sequel::Model.db, migrations_dir
-        if migrator.respond_to?(:applied_migrations)
-          migrator.applied_migrations[-2] || '0'
-        elsif migrator.respond_to?(:current_version)
-          migrator.current_version - 1
+        temporarily_merge_migration_files("determine the previous_migration") do
+          migrator_class = ::Sequel::Migrator.send(:migrator_class, migrations_dir)
+          migrator = migrator_class.new ::Sequel::Model.db, migrations_dir
+          if migrator.respond_to?(:applied_migrations)
+            migrator.applied_migrations[-2] || '0'
+          elsif migrator.respond_to?(:current_version)
+            migrator.current_version - 1
+          end
         end
       end
 
       def available_migrations?
-        File.exist?(migrations_dir) && Dir[File.join(migrations_dir, '*')].any?
+        temporarily_merge_migration_files do
+          File.exist?(migrations_dir) && Dir[File.join(migrations_dir, '*')].any?
+        end
       end
+
+      # Temporarily merges the migration files and then moves them back. Sequel's migration class cannot work
+      # with migrations in different directories even if sequel-rails can. This is the simplest solution that works
+      # until ::Sequel::Migrator supports merging of multiple migration directories.
+      def temporarily_merge_migration_files(explanation=nil)
+        copy_files = []
+        Rails.application.config.paths["db/migrate"].expanded.each do |specified_migration_dir|
+          if migrations_dir.to_s != specified_migration_dir
+            Dir[File.join(specified_migration_dir, '*')].each do |file_name|
+              copy_files.push([file_name, migrations_dir.join(File.basename(file_name)).to_s])
+            end
+          end
+        end
+        if explanation && copy_files.any?
+          puts "Detected migration files outside of the main db/migrate directory. Copying them to db/migrate temporarily to #{explanation}:"
+          copy_files.each { |o, _| puts " - #{o}"}
+        end
+        copy_files.each { |original, destination| FileUtils.cp(original, destination) }
+        yield
+      ensure
+        copy_files.each { |_, destination| FileUtils.rm_f(destination) }
+      end
+
     end
   end
 end


### PR DESCRIPTION
This is currently supported by Rails with ActiveRecord, but not with sequel-rails.

Sequel does not support multiple directories, so I simply copy the files over
temporarily.

Solves #129 