### PR TITLE
Add a "path" argument to Sequel::Generators::Base.source_root

### DIFF
--- a/lib/generators/sequel.rb
+++ b/lib/generators/sequel.rb
@@ -11,7 +11,8 @@ module Sequel
         @_sequel_base_name ||= 'sequel'
       end
 
-      def self.source_root
+      def self.source_root(path = nil)
+        @_sequel_source_root = path if path
         @_sequel_source_root ||= File.expand_path(
           "../#{base_name}/#{generator_name}/templates", __FILE__
         )


### PR DESCRIPTION
`Sequel::Generators::Base.source_root` method does not take a `path` argument, which [diverges](https://github.com/rails/rails/blob/master/railties/lib/rails/generators/base.rb#L23) from `Rails::Generators::Base` API. The `path` argument is very useful for creating custom generators with templates, for example:

```ruby
# lib/generators/foo/install/install_generator.rb
class Foo::Generators::InstallGenerator < ::Sequel::Generators::Base
  include Sequel::Generators::Migration
  source_root File.expand_path('../templates', __FILE__) # will not work, but would work with Rails
  # ...
end

# templates are stored in lib/generators/foo/install/templates
```

This behaviour can be observed since Rails 3.0.