### PR TITLE
Spring support for Rails 5.1 

### DIFF
--- a/lib/sequel_rails/railtie.rb
+++ b/lib/sequel_rails/railtie.rb
@@ -74,8 +74,7 @@ module SequelRails
     initializer 'sequel.spring' do |_app|
       if defined?(::Spring::Application)
         class ::Spring::Application # rubocop:disable Style/ClassAndModuleChildren
-          include ::SequelRails::SpringSupport
-          alias_method_chain :disconnect_database, :sequel
+          prepend ::SequelRails::SpringSupport
         end
       end
     end

--- a/lib/sequel_rails/railties/spring_support.rb
+++ b/lib/sequel_rails/railties/spring_support.rb
@@ -1,8 +1,8 @@
 module SequelRails
   module SpringSupport
-    def disconnect_database_with_sequel
+    def disconnect_database
       Sequel::DATABASES.each(&:disconnect) if sequel_configured?
-      disconnect_database_without_sequel
+      super
     end
 
     private


### PR DESCRIPTION
The spring support code uses `alias_method_chain` which has been deprecated in Rails 5.1.0.beta1.