### PR TITLE
Fix string interpolation syntax

### DIFF
--- a/lib/sequel_rails/railties/database.rake
+++ b/lib/sequel_rails/railties/database.rake
@@ -37,7 +37,7 @@ namespace sequel_rails_namespace do
         load(file)
         ::Sequel::Migration.descendants.each { |m| m.apply(db_for_current_env, :up) }
       else
-        abort '#{file} doesn\'t exist yet. Run \'rake #{sequel_rails_namespace}:migrate\' to create it, then try again.'
+        abort "#{file} doesn't exist yet. Run 'rake #{sequel_rails_namespace}:migrate' to create it, then try again."
       end
     end
   end


### PR DESCRIPTION
`rake db:schema:load` has a malformed string for an error message. The message should display the name of the file and also properly namespace the display of the `migrate` task's name (e.g. `rake sequel:migrate`), but because the error string is single-quoted, this doesn't happen and the intended interpolated values are instead interpreted as literals.