### PR TITLE
Handle missing database

### DIFF
--- a/lib/sequel_rails/storage/postgres.rb
+++ b/lib/sequel_rails/storage/postgres.rb
@@ -65,6 +65,9 @@ module SequelRails
         # command. Seems to be only way to ensure *all* test connections
         # are closed
         nil
+      rescue Sequel::DatabaseConnectionError
+        # Will raise an error if the database doesn't exist.
+        nil
       end
 
       def encoding

--- a/lib/sequel_rails/storage/postgres.rb
+++ b/lib/sequel_rails/storage/postgres.rb
@@ -108,9 +108,9 @@ module SequelRails
       end
 
       def add_connection_settings(commands)
-        add_option commands, '--username', username
-        add_option commands, '--host', host
-        add_option commands, '--port', port.to_s
+        add_option commands, '--username', username unless username.blank?
+        add_option commands, '--host', host unless host.blank?
+        add_option commands, '--port', port.to_s unless port.to_s.blank? || port.to_s == "0"
       end
     end
   end

--- a/lib/sequel_rails/storage/postgres.rb
+++ b/lib/sequel_rails/storage/postgres.rb
@@ -22,6 +22,7 @@ module SequelRails
         with_pgpassword do
           commands = ['dropdb']
           add_connection_settings commands
+          add_flag commands, '--if-exists'
           commands << database
           safe_exec commands
         end

--- a/spec/lib/sequel_rails/storage/postgres_spec.rb
+++ b/spec/lib/sequel_rails/storage/postgres_spec.rb
@@ -69,7 +69,7 @@ describe SequelRails::Storage::Postgres, :postgres do
   describe '#_drop' do
     it 'uses the dropdb command' do
       expect(subject).to receive(:`).with(
-        "dropdb --username\\=#{username} --host\\=#{host} --port\\=#{port} #{database}"
+        "dropdb --username\\=#{username} --host\\=#{host} --port\\=#{port} --if-exists #{database}"
       )
       subject._drop
     end


### PR DESCRIPTION
This patch makes sequel-rails behave a bit more like ActiveRecord.

`db:setup` should be more resilient in that it won't fail to drop a database that doesn't exist.

Certain combinations of database.yml, ENV["DATABASE_URL"] and JDBC will now succeed when the port defaults to zero.