### PR TITLE
Fix db:create rake tasks

### DIFF
--- a/lib/sequel_rails/railtie.rb
+++ b/lib/sequel_rails/railtie.rb
@@ -68,7 +68,7 @@ module SequelRails
     end
 
     initializer 'sequel.connect' do |app|
-      ::SequelRails.setup ::Rails.env unless app.config.sequel[:skip_connect] or defined?(::Rake)
+      ::SequelRails.setup ::Rails.env unless app.config.sequel[:skip_connect] or $rails_rake_task
     end
 
     initializer 'sequel.spring' do |_app|

--- a/lib/sequel_rails/railtie.rb
+++ b/lib/sequel_rails/railtie.rb
@@ -68,7 +68,7 @@ module SequelRails
     end
 
     initializer 'sequel.connect' do |app|
-      ::SequelRails.setup ::Rails.env unless app.config.sequel[:skip_connect] or $rails_rake_task
+      ::SequelRails.setup ::Rails.env unless app.config.sequel[:skip_connect] or $0 =~ /rake/
     end
 
     initializer 'sequel.spring' do |_app|

--- a/lib/sequel_rails/railtie.rb
+++ b/lib/sequel_rails/railtie.rb
@@ -68,7 +68,7 @@ module SequelRails
     end
 
     initializer 'sequel.connect' do |app|
-      ::SequelRails.setup ::Rails.env unless app.config.sequel[:skip_connect]
+      ::SequelRails.setup ::Rails.env unless app.config.sequel[:skip_connect] or defined?(::Rake)
     end
 
     initializer 'sequel.spring' do |_app|

--- a/lib/sequel_rails/railties/database.rake
+++ b/lib/sequel_rails/railties/database.rake
@@ -45,6 +45,7 @@ namespace sequel_rails_namespace do
   namespace :structure do
     desc 'Dump the database structure to db/structure.sql'
     task :dump, [:env] => :environment do |_t, args|
+      db_for_current_env
       args.with_defaults(:env => Rails.env)
 
       filename = ENV['DB_STRUCTURE'] || File.join(Rails.root, 'db', 'structure.sql')
@@ -126,6 +127,7 @@ namespace sequel_rails_namespace do
   namespace :migrate do
     task :load => :environment do
       require 'sequel_rails/migrations'
+      db_for_current_env
     end
 
     desc 'Rollbacks the database one migration and re migrate up. If you want to rollback more than one step, define STEP=x. Target specific version with VERSION=x.'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -53,6 +53,7 @@ end
 begin
   require 'sequel_rails/storage'
   require 'sequel/extensions/migration'
+  ::SequelRails.setup(Rails.env)
   load "#{Rails.root}/db/schema.rb.init"
   Sequel::Migration.descendants.first.apply Sequel::Model.db, :up
 rescue Sequel::DatabaseConnectionError => e


### PR DESCRIPTION
When running `rake db:create` with a default sequel-rails installation (testing this with Rails 5.1.4), the following exception occurs:

```
rake aborted!
Sequel::DatabaseConnectionError: PG::ConnectionBad: FATAL:  database "my_rails_app_development" does not exist
```

This happens because by default a connection is made to the configured database. This patch checks to see if we are running inside a Rake tasks and does not automatically connect if we do.

The Rake tasks themselves then call `db_for_current_env` if they need a connection to the database for the current environment. This only sets up a database connection in Rake tasks as needed.

This solves the exception on `db:create` for us and others remain working.