### PR TITLE
Do not connect to database on db:drop

### DIFF
--- a/lib/sequel_rails/railtie.rb
+++ b/lib/sequel_rails/railtie.rb
@@ -111,15 +111,17 @@ module SequelRails
     end
 
     def check_skip_connect_conditions(app)
-      app.config.sequel[:skip_connect] ||= database_create_command?
+      app.config.sequel[:skip_connect] ||= command_requiring_no_connection?
     end
 
     def database_connection_required?(app)
       !app.config.sequel[:skip_connect]
     end
 
-    def database_create_command?
-      ARGV.include?("db:create")
+    def command_requiring_no_connection?
+      no_connection_commands = ["db:create", "db:drop"]
+
+      ARGV.any? { |item| no_connection_commands.include?(item) }
     end
   end
 end


### PR DESCRIPTION
Same problem as #148, this time for db:drop

There might be a more sustainable fix possible that just defaults to no
connection all the time except for migrate or schema:load commands maybe
but for now this is an easy fix with a simple modification of the
existing command check I added for db:create.

Fixes #151