### PR TITLE
Fix Sequel::DatabaseConnectionError on db:create:all task

### DIFF
--- a/lib/sequel_rails/railtie.rb
+++ b/lib/sequel_rails/railtie.rb
@@ -119,7 +119,7 @@ module SequelRails
     end
 
     def database_create_command?
-      ARGV.include?("db:create")
+      ["db:create", "db:create:all"].any? { |c| ARGV.include?(c) }
     end
   end
 end


### PR DESCRIPTION
Prior to this commit, running bin/rails db:create:all in a new Rails
app with sequel-rails configured to replace ActiveRecord resulted in
this error:

Sequel::DatabaseConnectionError: PG::ConnectionBad: FATAL:  database "rails_app_development" does not exist

It then failed to create either the development or test databases.

This commit includes db:create:all in the commands checked to enable
skip_connect and avoid attempting to connect to the database before it's
been created.

Previously only db:create was checked. I don't want to make the check
too permissive so I'm specifying the full command and still checking
the ARGV array of command line arguments.

This extends the fix I originally submitted with #148.