### PR TITLE
Raise useful exception when db/migrate directory is absent

### DIFF
--- a/lib/sequel_rails/migrations.rb
+++ b/lib/sequel_rails/migrations.rb
@@ -6,7 +6,13 @@ module SequelRails
       def migrate(version = nil)
         opts = {}
         opts[:target] = version.to_i if version
-        ::Sequel::Migrator.run(::Sequel::Model.db, migrations_dir, opts)
+
+        if migrations_dir.directory?
+          ::Sequel::Migrator.run(::Sequel::Model.db, migrations_dir, opts)
+        else
+          relative_path_name = migrations_dir.relative_path_from(Rails.root).to_s
+          raise "The #{relative_path_name} directory doesn't exist, you need to create it."
+        end
       end
       alias_method :migrate_up!, :migrate
       alias_method :migrate_down!, :migrate


### PR DESCRIPTION
Currently when you run `bin/rails db:migrate` on a fresh rails app
created with: `rails new appname --skip-active-record` you don't get a
`db/migrate` directory which results in this exception:

```
rails aborted!
Errno::ENOENT: No such file or directory @ dir_initialize - .../db/migrate
.../oss/sequel-rails/lib/sequel_rails/migrations.rb:9:in `migrate'
.../oss/sequel-rails/lib/sequel_rails/railties/database.rake:166:in `block (2 levels) in <top (required)>'
.../sandbox/appname/bin/rails:9:in `require'
.../sandbox/appname/bin/rails:9:in `<top (required)>'
.../sandbox/appname/bin/spring:15:in `<top (required)>'
bin/rails:3:in `load'
bin/rails:3:in `<main>'
Tasks: TOP => db:migrate
(See full trace by running task with --trace)
```

With this fix SequelRails will catch this issue before it's too late and
gets to Sequel's migration logic (which assumes db/migrate exists). This
is the error produced now:

```
rails aborted!
The db/migrate directory doesn't exist, you need to create it.
.../oss/sequel-rails/lib/sequel_rails/migrations.rb:14:in `migrate'
.../oss/sequel-rails/lib/sequel_rails/railties/database.rake:166:in `block (2 levels) in <top (required)>'
.../sandbox/appname/bin/rails:9:in `require'
.../sandbox/appname/bin/rails:9:in `<top (required)>'
.../sandbox/appname/bin/spring:15:in `<top (required)>'
bin/rails:3:in `load'
bin/rails:3:in `<main>'
Tasks: TOP => db:migrate
(See full trace by running task with --trace)
```

After following the instruction from the error `mkdir -p db/migrate`,
you'll then get this much friendlier error from Sequel::Migrator itself:

```
$ bin/rails db:migrate
rails aborted!
Sequel::Migrator::Error: No target version available, probably because no migration files found or filenames don't follow the migration filename convention
.../oss/sequel-rails/lib/sequel_rails/migrations.rb:11:in `migrate'
.../oss/sequel-rails/lib/sequel_rails/railties/database.rake:166:in `block (2 levels) in <top (required)>'
.../sandbox/appname/bin/rails:9:in `require'
.../sandbox/appname/bin/rails:9:in `<top (required)>'
.../sandbox/appname/bin/spring:15:in `<top (required)>'
bin/rails:3:in `load'
bin/rails:3:in `<main>'
Tasks: TOP => db:migrate
(See full trace by running task with --trace)
```