### PR TITLE
Check that db/ exists before running db:schema:load

### DIFF
--- a/lib/sequel_rails/railties/database.rake
+++ b/lib/sequel_rails/railties/database.rake
@@ -22,11 +22,17 @@ namespace sequel_rails_namespace do
     task :dump => :environment do
       db_for_current_env.extension :schema_dumper
       filename = ENV['SCHEMA'] || "#{Rails.root}/db/schema.rb"
-      File.open filename, 'w' do |file|
-        file << db_for_current_env.dump_schema_migration(:same_db => true)
-        file << SequelRails::Migrations.dump_schema_information(:sql => false)
+
+      if Rails.root.join("db").exist?
+        File.open filename, 'w' do |file|
+          file << db_for_current_env.dump_schema_migration(:same_db => true)
+          file << SequelRails::Migrations.dump_schema_information(:sql => false)
+        end
+
+        Rake::Task["#{sequel_rails_namespace}:schema:dump"].reenable
+      else
+        abort "The db/ directory doesn't exist, please create it."
       end
-      Rake::Task["#{sequel_rails_namespace}:schema:dump"].reenable
     end
 
     desc 'Load a schema.rb file into the database'


### PR DESCRIPTION
**Note**: I promise I'm not trying to DDoS you with Pull Requests. :-)

This is essentially the same issue as #156. An easy fix and useful
feedback for users who created a Rails app without ActiveRecord and
will not have any `db/` directory.

The feedback is:

```
$ bin/rails db:schema:dump
The db/ directory doesn't exist, please create it.
```

Compare to what happened before this commit:

```
$ bin/rails db:schema:dump
rails aborted!
Errno::ENOENT: No such file or directory @ rb_sysopen - .../sandbox/appname/db/schema.rb
.../oss/sequel-rails/lib/sequel_rails/railties/database.rake:26:in `initialize'
.../oss/sequel-rails/lib/sequel_rails/railties/database.rake:26:in `open'
.../oss/sequel-rails/lib/sequel_rails/railties/database.rake:26:in `block (3 levels) in <top (required)>'
.../sandbox/appname/bin/rails:9:in `require'
.../sandbox/appname/bin/rails:9:in `<top (required)>'
.../sandbox/appname/bin/spring:15:in `<top (required)>'
bin/rails:3:in `load'
bin/rails:3:in `<main>'
Tasks: TOP => db:schema:dump
(See full trace by running task with --trace)
```