### PR TITLE
Allow 'servers' to propagate to Sequel connection

### DIFF
--- a/lib/sequel_rails/configuration.rb
+++ b/lib/sequel_rails/configuration.rb
@@ -73,6 +73,7 @@ module SequelRails
 
       config['max_connections'] = max_connections if max_connections
       config['search_path'] = search_path if search_path
+      config['servers'] = servers if servers
       config['test'] = test_connect
 
       url = ENV['DATABASE_URL']

--- a/lib/sequel_rails/db_config.rb
+++ b/lib/sequel_rails/db_config.rb
@@ -73,8 +73,8 @@ module SequelRails
         return URI::Generic.build(:scheme => adapter, :opaque => database)
       end
 
-      # these four are handled separately
-      params = cfg.reject { |k, _| %w(adapter host port database).include? k }
+      # these are handled separately
+      params = cfg.reject { |k, _| non_params.include? k }
 
       if (v = params['search_path'])
         # make sure there's no whitespace
@@ -95,6 +95,10 @@ module SequelRails
         :path => path,
         :query => q
       )
+    end
+
+    def non_params
+      %w(adapter host port database servers)
     end
   end
 end

--- a/spec/lib/sequel_rails/configuration_spec.rb
+++ b/spec/lib/sequel_rails/configuration_spec.rb
@@ -204,6 +204,44 @@ describe SequelRails::Configuration do
         end
       end
 
+      shared_examples 'servers' do
+        context 'servers' do
+          let(:servers) { { read_only: { host: 'replica' } } }
+
+          shared_examples 'passes the value only through options hash' do
+            it 'passes the value only through options hash' do
+              expect(::Sequel).to receive(:connect) do |hash_or_url, *_|
+                if hash_or_url.is_a? Hash
+                  servers.keys.each do |k|
+                    expect(hash_or_url[:servers][k]).to eq servers[k]
+                  end
+                else
+                  puts hash_or_url
+                  expect(hash_or_url).not_to include('servers=')
+                end
+              end
+              subject.connect environment
+            end
+          end
+
+          context 'with servers set in config' do
+            before do
+              subject.servers = servers
+            end
+
+            include_examples 'passes the value only through options hash'
+          end
+
+          context 'with servers set in environment' do
+            before do
+              environments[environment]['servers'] = servers
+            end
+
+            include_examples 'passes the value only through options hash'
+          end
+        end
+      end
+
       shared_examples 'with DATABASE_URL in ENV' do
         let(:database_url) { 'adapter://user:pass@host/db' }
         def with_database_url_env
@@ -283,6 +321,7 @@ describe SequelRails::Configuration do
           include_examples 'test_connect'
           include_examples 'max_connections'
           include_examples 'search_path'
+          include_examples 'servers'
           include_examples 'with DATABASE_URL in ENV'
 
           let(:is_jruby) { false }
@@ -299,6 +338,7 @@ describe SequelRails::Configuration do
           include_examples 'test_connect'
           include_examples 'max_connections'
           include_examples 'search_path'
+          include_examples 'servers'
           include_examples 'with DATABASE_URL in ENV'
 
           let(:is_jruby) { true }
@@ -332,6 +372,7 @@ describe SequelRails::Configuration do
         context 'in C-Ruby' do
           include_examples 'test_connect'
           include_examples 'max_connections'
+          include_examples 'servers'
           include_examples 'with DATABASE_URL in ENV'
 
           let(:is_jruby) { false }
@@ -347,6 +388,7 @@ describe SequelRails::Configuration do
         context 'in JRuby' do
           include_examples 'test_connect'
           include_examples 'max_connections'
+          include_examples 'servers'
           include_examples 'with DATABASE_URL in ENV'
 
           let(:is_jruby) { true }


### PR DESCRIPTION
This change allows `config.sequel.servers` to propagate properly to
Sequel::connect. It also blacklists this option from being sent to
an adapter via url query param.

The use-case is documented here:
https://github.com/jeremyevans/sequel/blob/master/doc/sharding.rdoc#primaryreplica-configurations-and-database-sharding