### PR TITLE
feat: add db:sessions clear and trim rake tasks

### DIFF
--- a/lib/sequel_rails/railties/database.rake
+++ b/lib/sequel_rails/railties/database.rake
@@ -213,6 +213,23 @@ namespace sequel_rails_namespace do
       Rails.env = previous_env
     end
   end
+
+  namespace :sessions do
+    desc 'Clear the sessions table'
+    task clear: :environment do
+      db_for_current_env.from(:sessions).truncate
+    end
+
+    desc 'Trim old sessions from the table (default: > 30 days)'
+    task :trim, [:threshold] => :environment do |_, args|
+      cutoff_period = (args.fetch(:threshold) { 30 }).to_i.days.ago
+
+      db_for_current_env
+        .from(:sessions)
+        .where { updated_at < cutoff_period }
+        .delete
+    end
+  end
 end
 
 task 'test:prepare' => "#{sequel_rails_namespace}:test:prepare"


### PR DESCRIPTION
This PR adds some rake tasks for managing the sessions table (`db:sessions:clear` and `db:sessions:trim`). This tasks are very similar to the ones found in [ActiveRecord::SessionStore](
https://github.com/rails/activerecord-session_store/blob/d7a918cc2b24b4261fead06538d7d8f8d8b2a1d1/lib/tasks/database.rake#L9-L200).