### PR TITLE
Use migrator with allow_missing_migration_files opt for dump schema

### DIFF
--- a/lib/sequel_rails/migrations.rb
+++ b/lib/sequel_rails/migrations.rb
@@ -30,8 +30,7 @@ module SequelRails
         res = ''
 
         if available_migrations?
-          migrator_class = ::Sequel::Migrator.send(:migrator_class, migrations_dir)
-          migrator = migrator_class.new db, migrations_dir
+          migrator = init_migrator
           res << adapter.schema_information_dump(migrator, sql)
         end
         res


### PR DESCRIPTION
This PR adds `allow_missing_migration_files` for `dump` command missed in prev PR.
ref: https://github.com/TalentBox/sequel-rails/pull/172