### PR TITLE
Add frozen_string_literal to migration template

### DIFF
--- a/lib/generators/sequel/migration/templates/migration.rb.erb
+++ b/lib/generators/sequel/migration/templates/migration.rb.erb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Sequel.migration do
   <%- if use_change -%>
   change do


### PR DESCRIPTION
Rubocop has rule https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/FrozenStringLiteralComment
which turned on by default.

@JonathanTron WDYT?