### PR TITLE
Database drop fix for Sequel (>= 5.38.0)

### DIFF
--- a/lib/sequel_rails/storage/abstract.rb
+++ b/lib/sequel_rails/storage/abstract.rb
@@ -15,7 +15,7 @@ module SequelRails
       end
 
       def drop
-        return if Sequel::DATABASES.size == 0
+        return if ::Sequel::DATABASES.size == 0
 
         ::Sequel::Model.db.disconnect
         res = _drop

--- a/lib/sequel_rails/storage/abstract.rb
+++ b/lib/sequel_rails/storage/abstract.rb
@@ -15,6 +15,8 @@ module SequelRails
       end
 
       def drop
+        return if Sequel::DATABASES.size == 0
+
         ::Sequel::Model.db.disconnect
         res = _drop
         warn "[sequel] Dropped database '#{database}'" if res

--- a/lib/sequel_rails/version.rb
+++ b/lib/sequel_rails/version.rb
@@ -1,3 +1,3 @@
 module SequelRails
-  VERSION = '1.1.1'.freeze
+  VERSION = '1.1.2'.freeze
 end

--- a/spec/lib/sequel_rails/storage/postgres_spec.rb
+++ b/spec/lib/sequel_rails/storage/postgres_spec.rb
@@ -83,6 +83,17 @@ describe SequelRails::Storage::Postgres, :postgres do
     end
   end
 
+  describe '#drop' do
+    before do
+      stub_const('Sequel::DATABASES', [])
+    end
+
+    it 'properly executes without active sequel connections' do
+      expect(Sequel::Model).not_to receive(:db)
+      subject.drop
+    end
+  end
+
   describe '#_dump' do
     let(:dump_file_name) { 'dump.sql' }
     it 'uses the pg_dump command' do


### PR DESCRIPTION
When we try to recreate a database using the `rails db:drop db:create` command with a non-existent database, we will crash when the `Sequel::Model#db` method is called. This happens because array `Sequel::DATABASES` is empty ([this](https://github.com/jeremyevans/sequel/issues/1727) change in Sequel).

I think we just need to check a size of `Sequel::DATABASES` before processing `#drop`.