### PR TITLE
chore: use after_connect hook within connection pool for each new connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,17 @@ You can configure some options with the usual rails mechanism, in
     # to fail early
     config.sequel.test_connect = true
 
+    # Configure what should happend after SequelRails will create new connection with Sequel (applicable only for the first new connection)
+    # config.sequel.after_connect = proc do
+    #   Sequel::Model.plugin :timestamps, update_on_create: true
+    # end
+
+    # Configure what should happend after new connection in connection pool is created (applicable only for all connections)
+    # to fail early
+    # config.sequel.after_new_connection = proc do |db|
+    #   db.execute('SET statement_timeout = 30000;')
+    # end
+
     # If you want to use a specific logger
     config.sequel.logger = MyLogger.new($stdout)
 ```
@@ -258,6 +269,25 @@ Here's some examples:
       adapter: sqlite # Also accept sqlite3
       database: ":memory:"
 ```
+
+after_connect hooks
+================
+
+There are 2 options how to set after_connect hooks in `config/application.rb`
+
+  1. `config.sequel.after_connect` will be called only on the first new connection. It can be used for enabling plugins or to set some global sequel settings.
+  ```ruby
+    config.sequel.after_connect = proc do
+      Sequel::Model.plugin :timestamps, update_on_create: true
+    end
+  ```
+
+  2. `config.sequel.after_new_connection` will be called after every new connection in connection pool is created. It can be used to run some specific `SET` commands on every new connection. It's using default `after_connect` hook in sequel. https://sequel.jeremyevans.net/rdoc/classes/Sequel/ConnectionPool.html#attribute-i-after_connect
+   ```ruby
+    config.sequel.after_new_connection = proc do |db|
+      db.execute('SET statement_timeout = 30000;')
+    end
+  ```
 
 Enabling plugins
 ================

--- a/lib/sequel_rails/configuration.rb
+++ b/lib/sequel_rails/configuration.rb
@@ -27,6 +27,7 @@ module SequelRails
       self.schema_dump = default_schema_dump
       self.load_database_tasks = true
       self.after_connect = nil
+      self.after_new_connection = nil
       self.skip_connect = nil
       self.test_connect = true
     end
@@ -59,7 +60,7 @@ module SequelRails
         ::Sequel.connect normalized_config['url'], SequelRails.deep_symbolize_keys(normalized_config)
       else
         ::Sequel.connect SequelRails.deep_symbolize_keys(normalized_config)
-      end
+      end.tap { after_connect.call if after_connect.respond_to?(:call) }
     end
 
     private
@@ -75,7 +76,7 @@ module SequelRails
       config['search_path'] = search_path if search_path
       config['servers'] = servers if servers
       config['test'] = test_connect
-      config['after_connect'] = after_connect if after_connect
+      config['after_connect'] = after_new_connection if after_new_connection
 
       url = ENV['DATABASE_URL']
       config['url'] ||= url if url

--- a/lib/sequel_rails/configuration.rb
+++ b/lib/sequel_rails/configuration.rb
@@ -59,7 +59,7 @@ module SequelRails
         ::Sequel.connect normalized_config['url'], SequelRails.deep_symbolize_keys(normalized_config)
       else
         ::Sequel.connect SequelRails.deep_symbolize_keys(normalized_config)
-      end.tap { after_connect.call if after_connect.respond_to?(:call) }
+      end
     end
 
     private
@@ -75,6 +75,7 @@ module SequelRails
       config['search_path'] = search_path if search_path
       config['servers'] = servers if servers
       config['test'] = test_connect
+      config['after_connect'] = after_connect if after_connect
 
       url = ENV['DATABASE_URL']
       config['url'] ||= url if url

--- a/spec/lib/sequel_rails/configuration_spec.rb
+++ b/spec/lib/sequel_rails/configuration_spec.rb
@@ -427,5 +427,16 @@ describe SequelRails::Configuration do
         subject.connect environment
       end
     end
+
+    describe 'after each connection hook' do
+      let(:hook) { double }
+      let(:environment) { 'development' }
+
+      it 'runs hook if provided' do
+        subject.after_new_connection = hook
+        expect(hook).to receive(:call)
+        subject.connect environment
+      end
+    end
   end
 end


### PR DESCRIPTION
### Motivation
Use `after_connect` hook in the proper way with each connection within the connection pool ([sequel doc](https://sequel.jeremyevans.net/rdoc/classes/Sequel/ConnectionPool.html#attribute-i-after_connect))

### Actual behavior 
Currently, there is `after_connect` executed only once for the Sequel connection instance, but it's not executed when creating new connection within connection pool


### Issue
With using sequel-rails with rails and multithreaded webserver (for example Puma) there is a need to utilize a connection pool for multiple connections. 
Let's say that we want to set statement_timeout for all connections in the connection pool.
```
config.sequel.after_connect = proc do |db|
  db.execute('SET statement_timeout = 30000;')
end
```
So with max_connections => 5 and running 
```
5.times{ Thread.new{ puts DB['SHOW statement_timeout'].to_a }}
```
there should be the same timeout -> 30s for all connections in the connection pool

@JonathanTron @JosephHalter 
Could you please take a look at that to verify all the changes? :) 