### PR TITLE
Brings GH pages up to date

### DIFF
--- a/index.html
+++ b/index.html
@@ -372,7 +372,7 @@ future version unintentionally.</li>
 <h1>
 <a name="copyright" class="anchor" href="#copyright"><span class="octicon octicon-link"></span></a>Copyright</h1>
 
-<p>Copyright (c) 2010-2022 The sequel-rails team. See <a href="http://github.com/brasten/sequel-rails/blob/master/LICENSE">LICENSE</a> for details.</p>
+<p>Copyright (c) 2010-2022 The sequel-rails team. See <a href="http://github.com/TalentBox/sequel-rails/blob/master/LICENSE">LICENSE</a> for details.</p>
         </section>
 
         <footer>

--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@
 
         <header>
           <h1>Sequel-rails</h1>
-          <h2>A gem for using Sequel with Rails 3.x and 4.x</h2>
+          <h2>A gem for using Sequel with Rails (5.2.x, 6.x, 7.x)</h2>
         </header>
 
         <section id="downloads" class="clearfix">
@@ -40,7 +40,7 @@
 
 <p>This gem provides the railtie that allows
 <a href="http://github.com/jeremyevans/sequel">sequel</a> to hook into
-<a href="http://github.com/rails/rails">Rails (3.x and 4.x)</a> and thus behave like a
+<a href="http://github.com/rails/rails">Rails (5.2.x, 6.x, 7.x)</a> and thus behave like a
 rails framework component. Just like activerecord does in rails,
 <a href="http://github.com/talentbox/sequel-rails">sequel-rails</a> uses the railtie API to
 hook into rails. The two are actually hooked into rails almost identically.</p>
@@ -58,7 +58,7 @@ support newer versions of rails.</p>
 <h1>
 <a name="using-sequel-rails" class="anchor" href="#using-sequel-rails"><span class="octicon octicon-link"></span></a>Using sequel-rails</h1>
 
-<p>Using sequel with Rails (3.x or 4.x) requires a couple minor changes.</p>
+<p>Using sequel with Rails (5.2.x, 6.x, 7.x) requires a couple minor changes.</p>
 
 <p>First, add the following to your Gemfile (after the <code>Rails</code> lines):</p>
 
@@ -283,7 +283,7 @@ you can do so in your <code>config/initializers/session.rb</code>:</p>
 <h1>
 <a name="available-sequel-specific-rake-tasks" class="anchor" href="#available-sequel-specific-rake-tasks"><span class="octicon octicon-link"></span></a>Available sequel specific rake tasks</h1>
 
-<p>To get a list of all available rake tasks in your rails3 app, issue the usual in you app's root directory:</p>
+<p>To get a list of all available rake tasks in your Rails app, issue the usual in you app's root directory:</p>
 
 <div class="highlight highlight-bash"><pre>rake -T
 </pre></div>

--- a/index.html
+++ b/index.html
@@ -372,7 +372,7 @@ future version unintentionally.</li>
 <h1>
 <a name="copyright" class="anchor" href="#copyright"><span class="octicon octicon-link"></span></a>Copyright</h1>
 
-<p>Copyright (c) 2010-2013 The sequel-rails team. See <a href="http://github.com/brasten/sequel-rails/blob/master/LICENSE">LICENSE</a> for details.</p>
+<p>Copyright (c) 2010-2022 The sequel-rails team. See <a href="http://github.com/brasten/sequel-rails/blob/master/LICENSE">LICENSE</a> for details.</p>
         </section>
 
         <footer>


### PR DESCRIPTION
As it says on the tin. 

The Github Pages are rather outdated in terms of referencing the supported Rails version numbers. I also noted the `gemspec` is rather outdated (I'll open a separate PR) and the Github repository description is also referring to older, unsupported (?) Rails versions. 

Question: are you using the Google Analytics tracking code at all? Otherwise, I'd advise simply removing it (which can be done in a separate PR).