### PR TITLE
Fix database_create_command? check

### DIFF
--- a/lib/sequel_rails/railtie.rb
+++ b/lib/sequel_rails/railtie.rb
@@ -116,7 +116,7 @@ module SequelRails
     end
 
     def database_create_command?
-      ['db:create', 'db:create:all'].any? { |c| ARGV.include?(c) }
+      ['db:create', 'db:create:all'].any? { |c| Rake.application.top_level_tasks.include?(c) }
     end
   end
 end


### PR DESCRIPTION
Currently this check doesn't work with `rails db:create` command since rails replaces ARGV. This fix makes it work for both `rails` and `rake` versions.