### PR TITLE
Fix color() method deprecation warning

### DIFF
--- a/lib/sequel_rails/railties/log_subscriber.rb
+++ b/lib/sequel_rails/railties/log_subscriber.rb
@@ -47,10 +47,10 @@ module SequelRails
         end
 
         if odd?
-          name = color(name, :cyan, true)
-          sql  = color(sql, nil, true)
+          name = color(name, :cyan, :bold => true)
+          sql  = color(sql, nil, :bold => true)
         else
-          name = color(name, :magenta, true)
+          name = color(name, :magenta, :bold => true)
         end
 
         debug "  #{name}  #{sql}#{binds}"


### PR DESCRIPTION
Hello, there is a deprecation warning in the latest rails - `Rails 7.1 Beta 1`
```
DEPRECATION WARNING: Bolding log text with a positional boolean is deprecated and will be removed in Rails 7.2. 
Use an option hash instead (eg. `color("my text", :red, bold: true)`). 
(called from sql at /usr/local/bundle/bundler/gems/sequel-rails-6ecf2114b606/lib/sequel_rails/railties/log_subscriber.rb:50)
```
This pr updates code to get rid of deprecation message. Works also with older versions of Rails, i've tested it with 7.0.8


Deprecation message was caused because of change in implementation of method color in `ActiveSupport`
- Method `color(text, color, bold = false)` before - [link](https://github.com/rails/rails/blob/fc734f28e65ef8829a1a939ee6702c1f349a1d5a/activesupport/lib/active_support/log_subscriber.rb#L139)
- Method `color(text, color, mode_options = {})` now - [link](https://github.com/rails/rails/blob/910eb470c5c2f1871117893fc33f5443bde8bf8d/activesupport/lib/active_support/log_subscriber.rb#L169)
