### PR TITLE
Allow to use commands db:test:prepare, db:setup without created DB

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,7 +377,7 @@ Once you do that, you will see the following rake tasks among others. These are 
 ```bash
 rake db:create[env]                   # Create the database defined in config/database.yml for the current Rails.env
 rake db:create:all                    # Create all the local databases defined in config/database.yml
-rake db:drop[env]                     # Create the database defined in config/database.yml for the current Rails.env
+rake db:drop[env]                     # Drop the database defined in config/database.yml for the current Rails.env
 rake db:drop:all                      # Drops all the local databases defined in config/database.yml
 rake db:force_close_open_connections  # Forcibly close any open connections to the test database
 rake db:migrate                       # Migrate the database to the latest version

--- a/lib/sequel_rails/railtie.rb
+++ b/lib/sequel_rails/railtie.rb
@@ -108,15 +108,17 @@ module SequelRails
     end
 
     def check_skip_connect_conditions(app)
-      app.config.sequel[:skip_connect] ||= database_create_command?
+      app.config.sequel[:skip_connect] ||= skip_db_connect?
     end
 
     def database_connection_required?(app)
       !app.config.sequel[:skip_connect]
     end
 
-    def database_create_command?
-      ['db:create', 'db:create:all'].any? { |c| Rake.application.top_level_tasks.include?(c) }
+    def skip_db_connect?
+      Rake.application.top_level_tasks.any? do |task|
+        task.match?(/^db:create|db:test:prepare|^db:drop|db:setup/)
+      end
     end
   end
 end


### PR DESCRIPTION
In case if app does not have db yet, commands db:create[env],
db:test:prepare, db:setup did not work, because they required
connection to not existed database. This commit adds ability to run
these commands regardless of whether the database exists or not.