### PR TITLE
Disconnect database connections before attempting to drop database

### DIFF
--- a/lib/sequel_rails/railties/database.rake
+++ b/lib/sequel_rails/railties/database.rake
@@ -206,6 +206,7 @@ namespace sequel_rails_namespace do
     desc "Prepare test database (ensure all migrations ran, drop and re-create database then load schema). This task can be run in the same invocation as other task (eg: rake #{sequel_rails_namespace}:migrate #{sequel_rails_namespace}:test:prepare)."
     task :prepare => "#{sequel_rails_namespace}:abort_if_pending_migrations" do
       previous_env, Rails.env = Rails.env, 'test'
+      Sequel::DATABASES.each(&:disconnect)
       Rake::Task["#{sequel_rails_namespace}:drop"].execute
       Rake::Task["#{sequel_rails_namespace}:create"].execute
       Rake::Task["#{sequel_rails_namespace}:load"].execute


### PR DESCRIPTION
Disconnecting all connections before attempting to drop the database solves a very common and annoying issue for me, where open connections created by the Rails application are still present when attempting to drop the test database.

It manifests itself as:
```
dropdb: error: database removal failed: ERROR:  database "rails-app-test" is being accessed by other users
DETAIL:  There is 1 other session using the database.
Couldn't drop database for environment test
createdb: error: database creation failed: ERROR:  database "rails-app-test" already exists
Could not create database for test.
```

This change fixes the problem.