### PR TITLE
Include ControllerRuntime in ActionController::API

### DIFF
--- a/lib/sequel_rails/railtie.rb
+++ b/lib/sequel_rails/railtie.rb
@@ -105,6 +105,7 @@ module SequelRails
     def setup_controller_runtime
       require 'sequel_rails/railties/controller_runtime'
       ActionController::Base.send :include, SequelRails::Railties::ControllerRuntime
+      ActionController::API.send :include, SequelRails::Railties::ControllerRuntime
     end
 
     def check_skip_connect_conditions(app)


### PR DESCRIPTION
It seems `SequelRails::Railties::LogSubscriber.count` and `SequelRails::Railties::LogSubscriber.runtime` don't work properly with API-only applications.